### PR TITLE
Fixed multiple sensor placement

### DIFF
--- a/nodeJsServer/public/js/gasLine.js
+++ b/nodeJsServer/public/js/gasLine.js
@@ -53,6 +53,15 @@ function changeLineColour(line, colour){
 	line.setOptions({strokeColor: colour});
 }
 
+function uniqueOnly(coord, index, self){
+	/**
+	* Check if coordinate objects are equal {lat: , lng:}
+	*/
+	return index === self.findIndex((t) => (
+			t.lat === coord.lat && t.lng === coord.lng
+			))
+}
+
 function createGasLine(ID, coords, interval, colour){
 	/**
 	* Create a gas line consisting of a SensorNet and Polyline.
@@ -60,9 +69,10 @@ function createGasLine(ID, coords, interval, colour){
 	* @param {number} interval The distance between sensors in meters.
 	* @param {string} colour colour of lines.
 	* @return {Object} {sensors : <SensorNet>, line : <Polyline>}
-	*/
-	var gasSensors = new SensorNet(coords, interval);
-	var gasLine = createLine(ID, coords, colour);
+	*/	
+	var uniqueCoords = coords.filter(uniqueOnly); //Remove duplicate coordinates	
+	var gasSensors = new SensorNet(uniqueCoords, interval);
+	var gasLine = createLine(ID, uniqueCoords, colour);
 
 	return {sensors : gasSensors, line : gasLine};
 }

--- a/nodeJsServer/public/js/locationUtils.js
+++ b/nodeJsServer/public/js/locationUtils.js
@@ -92,14 +92,12 @@ var LOCUTILS = (function (){
 		var dist = (d / interval) - ((d / interval) % 1).toFixed(6);
 		var counter = interval;
 		var coords = [];
-		coords.push({lat: lat1, lng: lng1});
 		var loopArray = Array.from({length: dist.toFixed(0)}, (x,i) => i);
 		for (distance in loopArray){
 			var coord = my.getDestinationLatLong(lat1,lng1,azimuth,counter);
 			counter = counter + interval;
 			coords.push(coord);
 		}
-		coords.push({lat: lat2, lng: lng2});
 		
 		return coords;
 	};

--- a/nodeJsServer/public/test/test.html
+++ b/nodeJsServer/public/test/test.html
@@ -1,3 +1,3 @@
 <script src="locationUtils.js"></script>
-<script src="GasLineCoords.js"></script>
 <script src="sensor.js"></script>
+<script src="GasLine.js"></script>


### PR DESCRIPTION
createGasLine now checks for and removes duplicate coordinates.

LocationUtils getLocations no longer returns the start and end coordinates for sensor placement.

Multiple sensor issue seems to be because the json file has two or more gas lines with common coordinates.